### PR TITLE
Add wasm test ensuring App renders aside component

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -12,6 +12,8 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
+      - name: Add wasm target
+        run: rustup target add wasm32-unknown-unknown
       - name: Install system dependencies
         run: |
           echo "deb http://gb.archive.ubuntu.com/ubuntu jammy main" | sudo tee /etc/apt/sources.list.d/jammy.list
@@ -31,8 +33,12 @@ jobs:
         run: cargo install create-tauri-app --locked
       - name: Install Tauri CLI
         run: cargo install tauri-cli --version "^2.0.0" --locked
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer.sh -sSf | sh
       - name: Test
         run: cargo test 
+      - name: Frontend wasm tests
+        run: CHROMEDRIVER=$(which chromedriver) wasm-pack test --headless --chrome --test frontend
       - name: Install cargo-tarpaulin
         run: cargo install cargo-tarpaulin
       - name: Backend coverage

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Tauri CLI
         run: cargo install tauri-cli --version "^2.0.0" --locked
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer.sh -sSf | sh
+        uses: jetli/wasm-pack-action@v0.4.0
       - name: Test
         run: cargo test 
       - name: Frontend wasm tests

--- a/tests/frontend.rs
+++ b/tests/frontend.rs
@@ -1,3 +1,6 @@
+#[cfg(target_arch = "wasm32")]
+#[path = "frontend/app_test.rs"]
+mod app;
 #[path = "frontend/components/mod.rs"]
 mod components;
 #[path = "frontend/models/mod.rs"]

--- a/tests/frontend/app_test.rs
+++ b/tests/frontend/app_test.rs
@@ -1,0 +1,25 @@
+#![cfg(target_arch = "wasm32")]
+
+use leptos::prelude::*;
+use parquetstudio_ui::app::App;
+use wasm_bindgen_test::wasm_bindgen_test;
+
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn given_app_component_when_mounted_then_should_render_aside_should_render_aside_component() {
+    console_error_panic_hook::set_once();
+
+    let window = web_sys::window().expect("window should be available");
+    let document = window.document().expect("document should be available");
+    let body = document.body().expect("document should have a body");
+    body.set_inner_html("");
+
+    mount_to_body(|| view! { <App /> });
+
+    let aside = document
+        .query_selector("aside")
+        .expect("selector should not fail");
+
+    assert!(aside.is_some(), "App should render an <aside> element");
+}

--- a/tests/frontend/app_test.rs
+++ b/tests/frontend/app_test.rs
@@ -3,6 +3,7 @@
 use leptos::prelude::*;
 use parquetstudio_ui::app::App;
 use wasm_bindgen_test::wasm_bindgen_test;
+use leptos::web_sys;
 
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
@@ -12,9 +13,6 @@ fn given_app_component_when_mounted_then_should_render_aside_should_render_aside
 
     let window = web_sys::window().expect("window should be available");
     let document = window.document().expect("document should be available");
-    let body = document.body().expect("document should have a body");
-    body.set_inner_html("");
-
     mount_to_body(|| view! { <App /> });
 
     let aside = document

--- a/webdriver.json
+++ b/webdriver.json
@@ -1,0 +1,6 @@
+{
+  "browserName": "chrome",
+  "goog:chromeOptions": {
+    "args": ["--headless=new","--disable-gpu","--no-sandbox","--disable-dev-shm-usage"]
+  }
+}


### PR DESCRIPTION
## Summary
- add a wasm-bindgen browser test that mounts the App component and asserts the aside element is rendered
- register the new app test module in the frontend test harness

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d963bb5ed08320a87a74d335208753