### PR TITLE
Conditionally gate backend dev dependencies for wasm builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ console_error_panic_hook = "0.1.7"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 parquetstudio_lib = { path = "src-tauri", package = "parquetstudio" }
 
 [workspace]

--- a/tests/backend.rs
+++ b/tests/backend.rs
@@ -1,2 +1,4 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 #[path = "backend/application/mod.rs"]
 mod application;

--- a/tests/backend/application/event_handler_test.rs
+++ b/tests/backend/application/event_handler_test.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 use parquetstudio_lib::application::event_handler::{
     resolve_menu_event_action, MenuEventAction,
 };

--- a/tests/backend/application/mod.rs
+++ b/tests/backend/application/mod.rs
@@ -1,1 +1,3 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 mod event_handler_test;


### PR DESCRIPTION
## Summary
- move `parquetstudio_lib` into a target-specific dev-dependency block so it is skipped for wasm32 builds
- gate backend integration tests with `#![cfg(not(target_arch = "wasm32"))]` to avoid compiling them for wasm targets

## Testing
- cargo test
- wasm-pack test --headless --chrome (fails: chromedriver download unavailable in sandbox)


------
https://chatgpt.com/codex/tasks/task_e_68d9b48d325483208b14e2f65d59eb3b